### PR TITLE
GRAPHICS-150: Set TTLs on subscriptions in Redis

### DIFF
--- a/scores-src/config/custom-environment-variables.json
+++ b/scores-src/config/custom-environment-variables.json
@@ -1,16 +1,17 @@
 {
-    "db": {
-        "connectionString": "DB_CONNECTION_STRING",
-        "username": "DB_USERNAME",
-        "password": "DB_PASSWORD",
-        "bucket": "DB_BUCKET",
-        "scope": "DB_SCOPE"
-    },
-    "port": "PORT",
-    "logLevel": "LOG_LEVEL",
-    "pathPrefix": "PATH_PREFIX",
-    "redis": {
-        "connectionString": "REDIS_CONNECTION_STRING"
-    },
-    "allowedOrigins": "ALLOWED_ORIGINS"
+  "db": {
+    "connectionString": "DB_CONNECTION_STRING",
+    "username": "DB_USERNAME",
+    "password": "DB_PASSWORD",
+    "bucket": "DB_BUCKET",
+    "scope": "DB_SCOPE"
+  },
+  "port": "PORT",
+  "logLevel": "LOG_LEVEL",
+  "pathPrefix": "PATH_PREFIX",
+  "redis": {
+    "connectionString": "REDIS_CONNECTION_STRING"
+  },
+  "allowedOrigins": "ALLOWED_ORIGINS",
+  "subscriptionLifetime": "SUBSCRIPTION_LIFETIME"
 }

--- a/scores-src/config/default.json
+++ b/scores-src/config/default.json
@@ -1,16 +1,17 @@
 {
-    "db": {
-        "connectionString": "couchbase://couchbase",
-        "username": "sports-scores",
-        "password": "password",
-        "bucket": "sports-scores",
-        "scope": "_default"
-    },
-    "logLevel": "info",
-    "pathPrefix": "/api",
-    "port": 8000,
-    "redis": {
-        "connectionString": "redis://localhost"
-    },
-    "allowedOrigins": []
+  "db": {
+    "connectionString": "couchbase://couchbase",
+    "username": "sports-scores",
+    "password": "password",
+    "bucket": "sports-scores",
+    "scope": "_default"
+  },
+  "logLevel": "info",
+  "pathPrefix": "/api",
+  "port": 8000,
+  "redis": {
+    "connectionString": "redis://localhost"
+  },
+  "allowedOrigins": [],
+  "subscriptionLifetime": 3600
 }

--- a/scores-src/src/server/config.ts
+++ b/scores-src/src/server/config.ts
@@ -18,6 +18,7 @@ const config = {
     typeof cfg.get("allowedOrigins") === "string"
       ? cfg.get<string>("allowedOrigins").split(",")
       : cfg.get<string[]>("allowedOrigins"),
+  subscriptionLifetime: cfg.get<number>("subscriptionLifetime"),
 };
 
 export default config;


### PR DESCRIPTION
We track the subscriptions of WS clients in Redis so that we can resubscribe them if they lose connection. Up until now though, we weren't cleaning up old ones.