### PR TITLE
Refactor Dockerfiles and Jenkinsfile to speed up builds

### DIFF
--- a/Dockerfile.bundle
+++ b/Dockerfile.bundle
@@ -1,36 +1,30 @@
 ARG NODECG_VERSION=1.8.1
-FROM node:16-slim AS build
+FROM registry.comp.ystv.co.uk/nodecg/nodecg:v${NODECG_VERSION} AS build
 ENV CI=true
 RUN apt-get update && apt-get install build-essential python3 -y
 
-WORKDIR /app
-COPY .yarnrc.yml /app/
-COPY .yarn /app/.yarn
+WORKDIR /usr/src/app/bundles/ystv-sports-graphics
+COPY .yarnrc.yml /usr/src/app/bundles/ystv-sports-graphics/
+COPY .yarn /usr/src/app/bundles/ystv-sports-graphics/.yarn
 
-COPY patches/ /app/patches/
-COPY package.json /app/
-COPY scores-src/package.json /app/scores-src/
-COPY bundle-src/package.json /app/bundle-src/
-COPY yarn.lock /app/
+COPY patches/ /usr/src/app/bundles/ystv-sports-graphics/patches/
+COPY package.json /usr/src/app/bundles/ystv-sports-graphics/
+COPY scores-src/package.json /usr/src/app/bundles/ystv-sports-graphics/scores-src/
+COPY bundle-src/package.json /usr/src/app/bundles/ystv-sports-graphics/bundle-src/
+COPY yarn.lock /usr/src/app/bundles/ystv-sports-graphics/
 
 RUN yarn --immutable --inline-builds && rm .yarn/cache/*
 # Everything up to here *must* be identical to Dockerfile.common
 
-# Mildly filthy hack: we need to build _inside_ a nodecg, because we
-# use relative references to its types
-FROM registry.comp.ystv.co.uk/nodecg/nodecg:v${NODECG_VERSION} AS bundle_build
-
-COPY .yarnrc.yml /usr/src/app/bundles/ystv-sports-graphics/
-COPY .yarn/ /usr/src/app/bundles/ystv-sports-graphics/.yarn/
-COPY package.json yarn.lock /usr/src/app/bundles/ystv-sports-graphics/
 COPY scores-src/ /usr/src/app/bundles/ystv-sports-graphics/scores-src/
 COPY bundle-src/ /usr/src/app/bundles/ystv-sports-graphics/bundle-src/
-COPY --from=build /app/node_modules/ /usr/src/app/bundles/ystv-sports-graphics/node_modules/
-WORKDIR /usr/src/app/bundles/ystv-sports-graphics
 RUN yarn bundle:build
 
 FROM registry.comp.ystv.co.uk/nodecg/nodecg:v${NODECG_VERSION}
-COPY --from=bundle_build /usr/src/app/bundles/ystv-sports-graphics/ /usr/src/app/bundles/ystv-sports-graphics/
+COPY --from=build /usr/src/app/bundles/ystv-sports-graphics/package.json /usr/src/app/bundles/ystv-sports-graphics/package.json
+COPY --from=build /usr/src/app/bundles/ystv-sports-graphics/extension.js /usr/src/app/bundles/ystv-sports-graphics/extension.js
+COPY --from=build /usr/src/app/bundles/ystv-sports-graphics/dashboard/ /usr/src/app/bundles/ystv-sports-graphics/dashboard/
+COPY --from=build /usr/src/app/bundles/ystv-sports-graphics/graphics/ /usr/src/app/bundles/ystv-sports-graphics/graphics/
 
 ARG GIT_REV=unknown
 LABEL ystv.git-rev=${GIT_REV}

--- a/Dockerfile.client
+++ b/Dockerfile.client
@@ -1,4 +1,5 @@
-FROM node:16-slim AS build
+ARG NODECG_VERSION=1.8.1
+FROM registry.comp.ystv.co.uk/nodecg/nodecg:v${NODECG_VERSION} AS build
 ENV CI=true
 RUN apt-get update && apt-get install build-essential python3 -y
 

--- a/Dockerfile.common
+++ b/Dockerfile.common
@@ -1,4 +1,5 @@
-FROM node:16-slim AS build
+ARG NODECG_VERSION=1.8.1
+FROM registry.comp.ystv.co.uk/nodecg/nodecg:v${NODECG_VERSION} AS build
 ENV CI=true
 RUN apt-get update && apt-get install build-essential python3 -y
 

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -1,4 +1,5 @@
-FROM node:16-slim AS build
+ARG NODECG_VERSION=1.8.1
+FROM registry.comp.ystv.co.uk/nodecg/nodecg:v${NODECG_VERSION} AS build
 ENV CI=true
 RUN apt-get update && apt-get install build-essential python3 -y
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,4 @@
+def imageNamePrefix = ''
 pipeline {
     agent {
         label 'docker'
@@ -8,29 +9,39 @@ pipeline {
     }
     
     stages {
+        stage('Prepare') {
+            steps {
+                script {
+                    if (env.BRANCH_NAME != 'main') {
+                        imageNamePrefix = "${env.BRANCH_NAME}-"
+                    }
+                }
+            }
+        }
         stage('Download Dependencies') {
             steps {
                 sh 'docker build -f Dockerfile.common .'
             }
         }
-
-        stage('Build') {
+        stage('Build Images') {
             parallel {
+                // bundle uses a different base image because its builds are done inside of NodeCG,
+                // so it can't take advantage of the Dockerfile.common trick
+                stage('Bundle') {
+                    steps {
+                        withDockerRegistry(credentialsId: 'docker-registry', url: 'https://registry.comp.ystv.co.uk') {
+                            sh "docker build --build-arg GIT_REV=${env.GIT_COMMIT} -t registry.comp.ystv.co.uk/sports-scores/bundle:${imageNamePrefix}${env.BUILD_NUMBER} -f Dockerfile.bundle ."
+                        }
+                    }
+                }
                 stage('Server') {
                     steps {
-                        sh "docker build --build-arg GIT_REV=${env.GIT_COMMIT} -t registry.comp.ystv.co.uk/sports-scores/server:${env.BUILD_NUMBER} -f Dockerfile.server ."
+                        sh "docker build --build-arg GIT_REV=${env.GIT_COMMIT} -t registry.comp.ystv.co.uk/sports-scores/server:${imageNamePrefix}${env.BUILD_NUMBER} -f Dockerfile.server ."
                     }
                 }
                 stage('Client') {
                     steps {
-                        sh "docker build --build-arg GIT_REV=${env.GIT_COMMIT} -t registry.comp.ystv.co.uk/sports-scores/client:${env.BUILD_NUMBER} -f Dockerfile.client ."
-                    }
-                }
-                stage('Bundle') {
-                    steps {
-                        withDockerRegistry(credentialsId: 'docker-registry', url: 'https://registry.comp.ystv.co.uk') {
-                            sh "docker build --build-arg GIT_REV=${env.GIT_COMMIT} -t registry.comp.ystv.co.uk/sports-scores/bundle:${env.BUILD_NUMBER} -f Dockerfile.bundle ."
-                        }
+                        sh "docker build --build-arg GIT_REV=${env.GIT_COMMIT} -t registry.comp.ystv.co.uk/sports-scores/client:${imageNamePrefix}${env.BUILD_NUMBER} -f Dockerfile.client ."
                     }
                 }
             }
@@ -39,15 +50,19 @@ pipeline {
         stage('Push') {
             steps {
                 withDockerRegistry(credentialsId: 'docker-registry', url: 'https://registry.comp.ystv.co.uk') {
-                    sh "docker push registry.comp.ystv.co.uk/sports-scores/client:${env.BUILD_NUMBER}"
-                    sh "docker push registry.comp.ystv.co.uk/sports-scores/server:${env.BUILD_NUMBER}"
-                    sh "docker push registry.comp.ystv.co.uk/sports-scores/bundle:${env.BUILD_NUMBER}"
-                    sh "docker tag registry.comp.ystv.co.uk/sports-scores/client:${env.BUILD_NUMBER} registry.comp.ystv.co.uk/sports-scores/client:latest"
-                    sh "docker tag registry.comp.ystv.co.uk/sports-scores/server:${env.BUILD_NUMBER} registry.comp.ystv.co.uk/sports-scores/server:latest"
-                    sh "docker tag registry.comp.ystv.co.uk/sports-scores/bundle:${env.BUILD_NUMBER} registry.comp.ystv.co.uk/sports-scores/bundle:latest"
-                    sh 'docker push registry.comp.ystv.co.uk/sports-scores/client:latest'
-                    sh 'docker push registry.comp.ystv.co.uk/sports-scores/server:latest'
-                    sh 'docker push registry.comp.ystv.co.uk/sports-scores/bundle:latest'
+                    sh "docker push registry.comp.ystv.co.uk/sports-scores/client:${imageNamePrefix}${env.BUILD_NUMBER}"
+                    sh "docker push registry.comp.ystv.co.uk/sports-scores/server:${imageNamePrefix}${env.BUILD_NUMBER}"
+                    sh "docker push registry.comp.ystv.co.uk/sports-scores/bundle:${imageNamePrefix}${env.BUILD_NUMBER}"
+                    script {
+                        if (env.BRANCH_NAME == 'main') {
+                            sh "docker tag registry.comp.ystv.co.uk/sports-scores/client:${imageNamePrefix}${env.BUILD_NUMBER} registry.comp.ystv.co.uk/sports-scores/client:latest"
+                            sh "docker tag registry.comp.ystv.co.uk/sports-scores/server:${imageNamePrefix}${env.BUILD_NUMBER} registry.comp.ystv.co.uk/sports-scores/server:latest"
+                            sh "docker tag registry.comp.ystv.co.uk/sports-scores/bundle:${imageNamePrefix}${env.BUILD_NUMBER} registry.comp.ystv.co.uk/sports-scores/bundle:latest"
+                            sh 'docker push registry.comp.ystv.co.uk/sports-scores/client:latest'
+                            sh 'docker push registry.comp.ystv.co.uk/sports-scores/server:latest'
+                            sh 'docker push registry.comp.ystv.co.uk/sports-scores/bundle:latest'
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
Switch out the base image of all the build stages to be NodeCG - that way we can cache the Yarn dependencies while still being able to build the bundle inside NodeCG and thus not need to install twice.

While we're at it, ensure we namespace all the Docker images we produce (any branch beginning with `jenkins-` will be built, and we don't want to clobber those), and only tag `:latest` with ones built from `main`.